### PR TITLE
Cool down the heatmap query rate

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,5 +4,5 @@
   "_heatmap_delay": "How old the tiles are that are shown in the heatmap in seconds. Realtime will most likely have too view tiles.",
   "heatmap_delay": 0.5,
   "_heatmap_tiles_limit": "The limit of how many tiles are queried and displayed on the map.",
-  "heatmap_tiles_limit": 5
+  "heatmap_tiles_limit": 30
 }

--- a/jobs/Heatmap.job.js
+++ b/jobs/Heatmap.job.js
@@ -4,4 +4,4 @@ setInterval(function() {
   es.tilesNSecondsAgo(function(body) {
     send_event('Heatmap', {hits: body.hits});
   }, 1);
-}, 100);
+}, 2*1000);

--- a/widgets/heatmap/heatmap.coffee
+++ b/widgets/heatmap/heatmap.coffee
@@ -30,11 +30,11 @@ class Dashing.Heatmap extends Dashing.Widget
       @previousData = []
       @round = 0
     @round++
-    if (@previousData[@round - 100] instanceof Array)
-      # console.log "deleting old data from round: "+ (@round - 100)
-      for i in @previousData[@round - 100]
+    if (@previousData[@round - 30] instanceof Array)
+      # console.log "deleting old data from round: "+ (@round - 30)
+      for i in @previousData[@round - 30]
         @vectorSource.removeFeature i
-      delete @previousData[@round - 100]
+      delete @previousData[@round - 30]
     @previousData[@round] = []
     for hit in data.hits
       point = new ol.geom.Point([hit._source["wmts.input_x"], hit._source["wmts.input_y"]])


### PR DESCRIPTION
Cool down the heatmap to a 0.5 Hz refreshing frequency. 
This is far less sexy than before but it does not crashes the log infrastructure.
